### PR TITLE
https support for dweb

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,6 +43,7 @@ dependencies = [
  "actix-codec",
  "actix-rt",
  "actix-service",
+ "actix-tls",
  "actix-utils",
  "base64",
  "bitflags 2.9.0",
@@ -174,6 +175,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "actix-tls"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac453898d866cdbecdbc2334fe1738c747b4eba14a677261f2b768ba05329389"
+dependencies = [
+ "actix-rt",
+ "actix-service",
+ "actix-utils",
+ "futures-core",
+ "impl-more",
+ "pin-project-lite",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "actix-utils"
 version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -196,6 +216,7 @@ dependencies = [
  "actix-rt",
  "actix-server",
  "actix-service",
+ "actix-tls",
  "actix-utils",
  "actix-web-codegen",
  "bytes",
@@ -659,7 +680,7 @@ dependencies = [
  "proptest",
  "rand 0.9.1",
  "ruint",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "serde",
  "sha3",
  "tiny-keccak",
@@ -1573,6 +1594,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fcc8f365936c834db5514fc45aee5b1202d677e6b40e48468aaaa8183ca8c7"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61b1d86e7705efe1be1b569bab41d4fa1e14e220b60a160f78de2db687add079"
+dependencies = [
+ "bindgen",
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1618,6 +1662,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.69.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
+dependencies = [
+ "bitflags 2.9.0",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.10.5",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 1.1.0",
+ "shlex",
+ "syn 2.0.101",
+ "which",
 ]
 
 [[package]]
@@ -1926,6 +1993,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1988,6 +2064,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
+
+[[package]]
 name = "clap"
 version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2041,6 +2128,15 @@ name = "clap_lex"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+
+[[package]]
+name = "cmake"
+version = "0.1.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "color-eyre"
@@ -2670,7 +2766,10 @@ dependencies = [
  "mime",
  "open",
  "qstring",
+ "rcgen",
  "regex",
+ "rustls",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "tokio",
@@ -3032,6 +3131,12 @@ checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "funty"
@@ -4074,10 +4179,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "libc"
 version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+
+[[package]]
+name = "libloading"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a793df0d7afeac54f95b471d3af7f0d4fb975699f972341a4b76988d49cdf0c"
+dependencies = [
+ "cfg-if",
+ "windows-targets 0.48.5",
+]
 
 [[package]]
 name = "libm"
@@ -5418,6 +5539,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "664ec5419c51e34154eec046ebcba56312d5a2fc3b09a06da188e1ad21afadf6"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.101",
+]
+
+[[package]]
 name = "prettytable"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5662,7 +5793,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "rustls",
  "socket2",
  "thiserror 2.0.12",
@@ -5682,7 +5813,7 @@ dependencies = [
  "lru-slab",
  "rand 0.9.1",
  "ring",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "rustls",
  "rustls-pki-types",
  "slab",
@@ -6127,6 +6258,12 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
@@ -6196,6 +6333,8 @@ version = "0.23.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "730944ca083c1c233a75c09f199e973ca499344a2b7ba9e755c457e86fb4a321"
 dependencies = [
+ "aws-lc-rs",
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -6239,6 +6378,7 @@ version = "0.103.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4a72fe2bcf7a6ac6fd7d0b9e5cb68aeb7d4c0a0271730218b3e92d43b4eb435"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",

--- a/dweb-cli/Cargo.toml
+++ b/dweb-cli/Cargo.toml
@@ -58,12 +58,15 @@ hex = "0.4.3"
 blsttc = "8.0.2"
 serde = "1.0.219"
 serde_json = "1.0.139"
-actix-web = "4.9.0"
+actix-web = { version = "4.9.0", features = ["rustls-0_23"] }
 actix-cors = "0.7.1"
 actix-multipart = "0.7.2"
 utoipa = { version = "5.3.1", features = ["actix_extras", "non_strict_integers"] }
 utoipa-actix-web = "0.1.2"
 utoipa-swagger-ui = { version = "9.0.1", features = ["vendored", "reqwest", "actix-web"] }
+rustls = "0.23"
+rustls-pemfile = "2.1"
+rcgen = "0.13"
 
 # patched
 #utoipa = { path = "../../utoipa-patch/utoipa", features = ["actix_extras", "non_strict_integers"] } # "5.3.1"

--- a/dweb-cli/src/cli_options.rs
+++ b/dweb-cli/src/cli_options.rs
@@ -155,6 +155,9 @@ pub enum Subcommands {
         /// This is only needed when not using defaults, so hidden to de-clutter the CLI help
         #[clap(hide = true, long, value_name = "PORT", value_parser = parse_port_number)]
         port: Option<u16>,
+        /// Enable HTTPS with automatically generated self-signed certificate
+        #[clap(long = "https", default_value = "false")]
+        https: bool,
     },
 
     /// Open a browser to view a website on Autonomi (requires 'dweb serve' running)

--- a/dweb-cli/src/commands/subcommands.rs
+++ b/dweb-cli/src/commands/subcommands.rs
@@ -44,6 +44,7 @@ pub async fn cli_commands(opt: Opt) -> Result<bool> {
             experimental,
             host,
             port,
+            https,
         }) => {
             let (client, is_local_network) =
                 connect_and_announce(opt.local, opt.alpha, api_control, true).await;
@@ -52,7 +53,11 @@ pub async fn cli_commands(opt: Opt) -> Result<bool> {
                 // Start the main server (for port based browsing), which will handle /dweb-open URLs  opened by 'dweb open'
                 let default_host = LOCALHOST_STR.to_string();
                 let host = host.unwrap_or(default_host);
-                let port = port.unwrap_or(SERVER_PORTS_MAIN_PORT);
+                let port = port.unwrap_or(if https { 
+                    dweb::web::DEFAULT_HTTPS_PORT 
+                } else { 
+                    SERVER_PORTS_MAIN_PORT 
+                });
                 match crate::services::serve_with_ports(
                     &client,
                     None,
@@ -60,6 +65,7 @@ pub async fn cli_commands(opt: Opt) -> Result<bool> {
                     Some(port),
                     false,
                     is_local_network,
+                    https,
                 )
                 .await
                 {
@@ -105,23 +111,22 @@ pub async fn cli_commands(opt: Opt) -> Result<bool> {
             if !experimental {
                 let default_host = LOCALHOST_STR.to_string();
                 let host = host.unwrap_or(default_host);
-                let port = port.unwrap_or(SERVER_PORTS_MAIN_PORT);
                 crate::commands::cmd_browse::handle_browse_with_ports(
                     &address_name_or_link,
                     version,
                     as_name,
                     remote_path,
                     Some(&host),
-                    Some(port),
+                    port,
                 );
             } else {
                 let default_host = dweb::web::DWEB_SERVICE_API.to_string();
                 let host = host.unwrap_or(default_host);
                 let port = port.unwrap_or(SERVER_HOSTS_MAIN_PORT);
-                crate::commands::cmd_browse::handle_browse_with_ports(
+                crate::commands::cmd_browse::handle_browse_with_hosts(
+                    None,
                     &address_name_or_link,
                     version,
-                    as_name,
                     remote_path,
                     Some(&host),
                     Some(port),

--- a/dweb-cli/src/services/www/dweb_open.rs
+++ b/dweb-cli/src/services/www/dweb_open.rs
@@ -135,6 +135,14 @@ pub async fn dweb_open_as(
     .await
 }
 
+/// Detect if the main server is running with HTTPS
+fn detect_main_server_https_status() -> bool {
+    use dweb::cache::spawn::detect_server_protocol;
+    
+    let (_, protocol) = detect_server_protocol();
+    matches!(protocol, Some(dweb::cache::spawn::ServerProtocol::Https))
+}
+
 pub async fn handle_dweb_open(
     request: &HttpRequest,
     client: Data<dweb::client::DwebClient>,
@@ -176,7 +184,7 @@ pub async fn handle_dweb_open(
                     None,
                     true,
                     *is_local_network.into_inner().as_ref(),
-                    true, // HTTPS for spawned servers too
+                    detect_main_server_https_status(),
                 )
                 .await
                 {

--- a/dweb-cli/src/services/www/dweb_open.rs
+++ b/dweb-cli/src/services/www/dweb_open.rs
@@ -176,6 +176,7 @@ pub async fn handle_dweb_open(
                     None,
                     true,
                     *is_local_network.into_inner().as_ref(),
+                    true, // HTTPS for spawned servers too
                 )
                 .await
                 {

--- a/dweb-lib/src/cache/spawn.rs
+++ b/dweb-lib/src/cache/spawn.rs
@@ -20,6 +20,40 @@
 // TODO web API and CLI for listing active ports and what they are serving
 // TODO see TODOs in serve_with_ports()
 
+use std::net::TcpStream;
+use std::time::Duration;
+use crate::web::{SERVER_PORTS_MAIN_PORT, DEFAULT_HTTPS_PORT, LOCALHOST_STR};
+
+#[derive(Debug, Clone, Copy)]
+pub enum ServerProtocol {
+    Http,
+    Https,
+}
+
 pub fn is_main_server_with_ports_running() -> bool {
     return true; // TODO look-up the main server in the spawned servers struct
+}
+
+/// Detect if a dweb server is running and which protocol (HTTP/HTTPS) it uses
+/// Returns (is_running, protocol) where protocol is None if no server is detected
+pub fn detect_server_protocol() -> (bool, Option<ServerProtocol>) {
+    let timeout = Duration::from_millis(500);
+    
+    // Try HTTPS port first (8443)
+    if let Ok(_) = TcpStream::connect_timeout(
+        &format!("{}:{}", LOCALHOST_STR, DEFAULT_HTTPS_PORT).parse().unwrap(),
+        timeout
+    ) {
+        return (true, Some(ServerProtocol::Https));
+    }
+    
+    // Try HTTP port (8080)
+    if let Ok(_) = TcpStream::connect_timeout(
+        &format!("{}:{}", LOCALHOST_STR, SERVER_PORTS_MAIN_PORT).parse().unwrap(),
+        timeout
+    ) {
+        return (true, Some(ServerProtocol::Http));
+    }
+    
+    (false, None)
 }


### PR DESCRIPTION
okay - i tested it locally and with this modification you can start dweb

`dweb serve --https`

if you want to run it via https (otherwise you just omit the flag)

`dweb open ...`

just as we're used to

i'm not perfectly happy with this implementation tbh because of 2 reasons:

1.

- first we start the server with https/http (so we should know what we did)
- on dweb open we detect if it's https or http (based on the used port)

...feels just a bit wrong ...

2.

with self signed certificate it's super annoying to accept it every  time i open the app (2x - once for the dweb server and once for the app server)

but on the upside it works and is okayish on code-clean-ness i'd hope ...?

---

only other idea that doesn't bloat the codebase i have is to write a state file ...